### PR TITLE
Update Linkero requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7"
   #- "nightly" # currently points to 3.7-dev
 # command to install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
   #- "nightly" # currently points to 3.7-dev
 # command to install dependencies
 install:

--- a/linkero/core/common.py
+++ b/linkero/core/common.py
@@ -10,7 +10,7 @@ from .ascii import ascii_warning
 
 class Metadata:
     def __init__(self):
-        self.__version__ = '0.9.10'
+        self.__version__ = '0.9.15'
         self.__author__ = 'Rubén de Celis Hernández'
 
     def get_version(self):

--- a/linkero/core/gateway/gevent_service.py
+++ b/linkero/core/gateway/gevent_service.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import linkero.core.linkero as linkero
-from gevent.wsgi import WSGIServer
+from gevent.pywsgi import WSGIServer
 from gevent.pool import Pool
 import os
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ flask-httpauth==3.1.2
 flask-cors==3.0.3
 passlib==1.6.5
 itsdangerous==0.24
-gevent>=1.2.1,<=1.2.2
+gevent>=1.2.1
 waitress>=1.0.2
 colorama>=0.3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ flask-restful>=0.3.5
 flask-sqlalchemy>=2.1
 flask-httpauth>=3.1.2
 flask-cors>=3.0.3
-passlib==1.6.5
+passlib>=1.6.5
 itsdangerous>=0.24
 gevent>=1.2.1
 waitress>=1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-flask-restful==0.3.5
-flask-sqlalchemy==2.1
-flask-httpauth==3.1.2
-flask-cors==3.0.3
+flask-restful>=0.3.5
+flask-sqlalchemy>=2.1
+flask-httpauth>=3.1.2
+flask-cors>=3.0.3
 passlib==1.6.5
 itsdangerous==0.24
 gevent>=1.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ flask-sqlalchemy>=2.1
 flask-httpauth>=3.1.2
 flask-cors>=3.0.3
 passlib==1.6.5
-itsdangerous==0.24
+itsdangerous>=0.24
 gevent>=1.2.1
 waitress>=1.0.2
 colorama>=0.3.7


### PR DESCRIPTION
Checking last release compatibility:
- Gevent ✔️
- Flask-restful ✔️
- Flask-sqlalchemy ✔️
- Flask-httpauth ✔️
- Flask-cors ✔️
- Passlib ✔️
- Itsdangerous ✔️